### PR TITLE
feat: dynamic system prompt with target language

### DIFF
--- a/src/lib/server/chat.service.ts
+++ b/src/lib/server/chat.service.ts
@@ -27,7 +27,7 @@ export async function getChatById(chatId: string, userId: string) {
 
 export async function getChatMessages(chatId: string, userId: string) {
 	const [result] = await db
-		.select({ messages: chat.messages, vocabulary: chat.vocabulary })
+		.select({ messages: chat.messages, vocabulary: chat.vocabulary, targetLanguage: chat.targetLanguage })
 		.from(chat)
 		.where(and(eq(chat.id, chatId), eq(chat.userId, userId)));
 	return result ?? null;

--- a/src/routes/api/chat/+server.ts
+++ b/src/routes/api/chat/+server.ts
@@ -11,7 +11,7 @@ import {
 	streamText,
 	type UIMessage
 } from 'ai';
-import { SystemPrompt } from './system-prompt';
+import { buildSystemPrompt } from './system-prompt';
 
 const openrouter = createOpenRouter({ apiKey: OPENROUTER_API_KEY });
 
@@ -30,7 +30,7 @@ export async function POST({ request }) {
 
 	const result = streamText({
 		model: openrouter.chat(OPENROUTER_MODEL_NAME),
-		system: SystemPrompt,
+		system: buildSystemPrompt({ targetLanguage: existing.targetLanguage }),
 		messages: await convertToModelMessages(messages),
 		tools,
 		stopWhen: stepCountIs(2)

--- a/src/routes/api/chat/system-prompt.ts
+++ b/src/routes/api/chat/system-prompt.ts
@@ -1,10 +1,11 @@
-export const SystemPrompt = `You are a friendly language tutor. Your goal is to help the user learn their target language naturally through conversation.
+export function buildSystemPrompt({ targetLanguage }: { targetLanguage: string }): string {
+	return `You are a friendly language tutor helping the user learn ${targetLanguage}. Your goal is to help them learn naturally through conversation.
 
-- Ask the user which language they want to learn and their current level if not established
-- Conduct conversations in a mix of the target language and English, adjusting ratio to the user's level
+- Conduct conversations in a mix of ${targetLanguage} and English, adjusting the ratio to the user's level
 - Correct mistakes gently: acknowledge what they said, then model the correct form
 - Introduce vocabulary and grammar through context, not drills
 - Keep responses concise and conversational — avoid long lectures
 - Encourage the user and celebrate progress
 
 At the end of every response, call the addVocabulary tool with any new vocabulary words you introduced in this response. Include the target-language word, its English translation, its grammatical part of speech, and a usage example sentence in the target language. If you did not introduce any new words, call addVocabulary with an empty array.`;
+}


### PR DESCRIPTION
Implements #issue 8: converts the static `SystemPrompt` constant to a `buildSystemPrompt({ targetLanguage })` function that injects the chat's target language so the tutor knows the language up front instead of asking for it.

Closes #8

Generated with [Claude Code](https://claude.ai/code)