### PR TITLE
feat: default new chat title to "New {targetLanguage} Chat"

### DIFF
--- a/src/lib/server/chat.service.ts
+++ b/src/lib/server/chat.service.ts
@@ -27,7 +27,11 @@ export async function getChatById(chatId: string, userId: string) {
 
 export async function getChatMessages(chatId: string, userId: string) {
 	const [result] = await db
-		.select({ messages: chat.messages, vocabulary: chat.vocabulary, targetLanguage: chat.targetLanguage })
+		.select({
+			messages: chat.messages,
+			vocabulary: chat.vocabulary,
+			targetLanguage: chat.targetLanguage
+		})
 		.from(chat)
 		.where(and(eq(chat.id, chatId), eq(chat.userId, userId)));
 	return result ?? null;
@@ -44,7 +48,7 @@ export async function getChatVocabulary(chatId: string, userId: string) {
 export async function createChat(userId: string, targetLanguage: string) {
 	const [newChat] = await db
 		.insert(chat)
-		.values({ userId, targetLanguage, title: targetLanguage })
+		.values({ userId, targetLanguage, title: `New ${targetLanguage} Chat` })
 		.returning({ id: chat.id });
 	return newChat;
 }


### PR DESCRIPTION
## Summary
Closes #14. New chats are now titled `New {targetLanguage} Chat` instead of just the bare language name.

## Changes
- `createChat` now sets `title: \`New ${targetLanguage} Chat\`` (e.g. **"New Spanish Chat"**). `targetLanguage` holds the display name, so no lookup is needed.
- The sidebar already prepends the flag, so it renders as e.g. `🇪🇸 New Spanish Chat`.

> A pre-existing long-line in `getChatMessages` was auto-reformatted by the repo's lint-staged/prettier hook — harmless, no behavior change.

## Testing
- `bun run check` passes for the changed code; the only remaining errors are pre-existing `$env/static/private` missing-`.env` issues unrelated to this change. The repo has no automated test setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)