### PR TITLE
feat: group, search, rename, and archive chats in sidebar

### DIFF
--- a/src/lib/components/app-sidebar.svelte
+++ b/src/lib/components/app-sidebar.svelte
@@ -3,15 +3,71 @@
 	import { goto } from '$app/navigation';
 	import { resolve } from '$app/paths';
 	import { authClient } from '$lib/auth-client';
+	import { Button } from '$lib/components/ui/button/index.js';
+	import * as Dialog from '$lib/components/ui/dialog/index.js';
+	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+	import { Input } from '$lib/components/ui/input/index.js';
 	import * as Sidebar from '$lib/components/ui/sidebar/index.js';
 	import { getLanguageFlag } from '$lib/languages';
 	import { chatStore } from '$lib/stores/chat-store.svelte';
+	import type { ChatSummary } from '$lib/types';
+	import ArchiveIcon from '@lucide/svelte/icons/archive';
+	import ArchiveRestoreIcon from '@lucide/svelte/icons/archive-restore';
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
 	import LogOutIcon from '@lucide/svelte/icons/log-out';
+	import MoreHorizontalIcon from '@lucide/svelte/icons/more-horizontal';
+	import PencilIcon from '@lucide/svelte/icons/pencil';
 	import PlusIcon from '@lucide/svelte/icons/plus';
+	import SearchIcon from '@lucide/svelte/icons/search';
 	import TrashIcon from '@lucide/svelte/icons/trash-2';
 
+	interface LanguageGroup {
+		language: string;
+		flag: string;
+		chats: ChatSummary[];
+	}
+
 	const session = authClient.useSession();
+
+	let searchQuery = $state('');
+	let showArchived = $state(false);
+	let renameOpen = $state(false);
+	let renameTarget = $state<ChatSummary | null>(null);
+	let renameValue = $state('');
+
 	const initial = $derived($session.data?.user.name?.charAt(0).toUpperCase() ?? '?');
+
+	const groupedChats = $derived.by(() => groupByLanguage(filterChats(chatStore.chats)));
+	const filteredArchivedChats = $derived(filterChats(chatStore.archivedChats));
+
+	function filterChats(chats: ChatSummary[]): ChatSummary[] {
+		const query = searchQuery.trim().toLowerCase();
+		if (!query) return chats;
+		return chats.filter((c) => c.title.toLowerCase().includes(query));
+	}
+
+	function groupByLanguage(chats: ChatSummary[]): LanguageGroup[] {
+		const groups: LanguageGroup[] = [];
+		for (const chat of chats) {
+			let group = groups.find((g) => g.language === chat.targetLanguage);
+			if (!group) {
+				group = {
+					language: chat.targetLanguage,
+					flag: getLanguageFlag(chat.targetLanguage),
+					chats: []
+				};
+				groups.push(group);
+			}
+			group.chats.push(chat);
+		}
+		return groups;
+	}
+
+	function openRename(chat: ChatSummary) {
+		renameTarget = chat;
+		renameValue = chat.title;
+		renameOpen = true;
+	}
 
 	async function logout() {
 		await authClient.signOut();
@@ -48,43 +104,185 @@
 		</Sidebar.Group>
 
 		<Sidebar.Group>
-			<Sidebar.GroupLabel>Chats</Sidebar.GroupLabel>
 			<Sidebar.GroupContent>
-				<Sidebar.Menu>
-					{#each chatStore.chats as chat (chat.id)}
-						<Sidebar.MenuItem>
-							<Sidebar.MenuButton isActive={chatStore.currentChatId === chat.id}>
-								{#snippet child({ props })}
-									<a href={resolve(`/chat/${chat.id}`)} {...props} title={chat.title}>
-										<span>{getLanguageFlag(chat.targetLanguage)} {chat.title}</span>
-									</a>
-								{/snippet}
-							</Sidebar.MenuButton>
-							<Sidebar.MenuAction>
-								<form
-									method="POST"
-									action="/?/deleteChat"
-									use:enhance={() =>
-										async ({ result, update }) => {
-											await update();
-											if (result.type === 'success') goto(resolve('/'));
-										}}
-								>
-									<input type="hidden" name="id" value={chat.id} />
-									<button
-										type="submit"
-										class="ml-auto p-1 text-muted-foreground opacity-0 group-hover/menu-item:opacity-100 hover:text-destructive"
-										aria-label="Delete chat"
-									>
-										<TrashIcon class="size-3.5" />
-									</button>
-								</form>
-							</Sidebar.MenuAction>
-						</Sidebar.MenuItem>
-					{/each}
-				</Sidebar.Menu>
+				<div class="relative">
+					<SearchIcon
+						class="pointer-events-none absolute top-1/2 left-2 size-4 -translate-y-1/2 text-muted-foreground"
+					/>
+					<Sidebar.Input
+						bind:value={searchQuery}
+						placeholder="Search chats..."
+						class="pl-8"
+						aria-label="Search chats"
+					/>
+				</div>
 			</Sidebar.GroupContent>
 		</Sidebar.Group>
+
+		{#each groupedChats as group (group.language)}
+			<Sidebar.Group>
+				<Sidebar.GroupLabel>{group.flag} {group.language}</Sidebar.GroupLabel>
+				<Sidebar.GroupContent>
+					<Sidebar.Menu>
+						{#each group.chats as chat (chat.id)}
+							<Sidebar.MenuItem>
+								<Sidebar.MenuButton isActive={chatStore.currentChatId === chat.id}>
+									{#snippet child({ props })}
+										<a href={resolve(`/chat/${chat.id}`)} {...props} title={chat.title}>
+											<span>{chat.title}</span>
+										</a>
+									{/snippet}
+								</Sidebar.MenuButton>
+								<DropdownMenu.Root>
+									<DropdownMenu.Trigger>
+										{#snippet child({ props })}
+											<Sidebar.MenuAction {...props} showOnHover aria-label="Chat options">
+												<MoreHorizontalIcon />
+											</Sidebar.MenuAction>
+										{/snippet}
+									</DropdownMenu.Trigger>
+									<DropdownMenu.Content side="right" align="start">
+										<DropdownMenu.Item onSelect={() => openRename(chat)}>
+											<PencilIcon />
+											<span>Rename</span>
+										</DropdownMenu.Item>
+										<DropdownMenu.Item closeOnSelect={false}>
+											{#snippet child({ props })}
+												<form
+													method="POST"
+													action="/?/archiveChat"
+													use:enhance={() =>
+														async ({ result, update }) => {
+															await update();
+															if (result.type === 'success' && chatStore.currentChatId === chat.id)
+																goto(resolve('/'));
+														}}
+												>
+													<input type="hidden" name="id" value={chat.id} />
+													<button type="submit" {...props}>
+														<ArchiveIcon />
+														<span>Archive</span>
+													</button>
+												</form>
+											{/snippet}
+										</DropdownMenu.Item>
+										<DropdownMenu.Separator />
+										<DropdownMenu.Item variant="destructive" closeOnSelect={false}>
+											{#snippet child({ props })}
+												<form
+													method="POST"
+													action="/?/deleteChat"
+													use:enhance={() =>
+														async ({ result, update }) => {
+															await update();
+															if (result.type === 'success') goto(resolve('/'));
+														}}
+												>
+													<input type="hidden" name="id" value={chat.id} />
+													<button type="submit" {...props}>
+														<TrashIcon />
+														<span>Delete</span>
+													</button>
+												</form>
+											{/snippet}
+										</DropdownMenu.Item>
+									</DropdownMenu.Content>
+								</DropdownMenu.Root>
+							</Sidebar.MenuItem>
+						{/each}
+					</Sidebar.Menu>
+				</Sidebar.GroupContent>
+			</Sidebar.Group>
+		{/each}
+
+		{#if chatStore.archivedChats.length > 0}
+			<Sidebar.Group>
+				<Sidebar.GroupLabel>
+					{#snippet child({ props })}
+						<button
+							{...props}
+							onclick={() => (showArchived = !showArchived)}
+							class="{props.class} flex w-full items-center gap-1"
+						>
+							<ChevronDownIcon
+								class="size-4 transition-transform {showArchived ? '' : '-rotate-90'}"
+							/>
+							<span>Archived</span>
+						</button>
+					{/snippet}
+				</Sidebar.GroupLabel>
+				{#if showArchived}
+					<Sidebar.GroupContent>
+						<Sidebar.Menu>
+							{#each filteredArchivedChats as chat (chat.id)}
+								<Sidebar.MenuItem>
+									<Sidebar.MenuButton isActive={chatStore.currentChatId === chat.id}>
+										{#snippet child({ props })}
+											<a href={resolve(`/chat/${chat.id}`)} {...props} title={chat.title}>
+												<span>{getLanguageFlag(chat.targetLanguage)} {chat.title}</span>
+											</a>
+										{/snippet}
+									</Sidebar.MenuButton>
+									<DropdownMenu.Root>
+										<DropdownMenu.Trigger>
+											{#snippet child({ props })}
+												<Sidebar.MenuAction {...props} showOnHover aria-label="Chat options">
+													<MoreHorizontalIcon />
+												</Sidebar.MenuAction>
+											{/snippet}
+										</DropdownMenu.Trigger>
+										<DropdownMenu.Content side="right" align="start">
+											<DropdownMenu.Item closeOnSelect={false}>
+												{#snippet child({ props })}
+													<form
+														method="POST"
+														action="/?/unarchiveChat"
+														use:enhance={() =>
+															async ({ update }) => {
+																await update();
+															}}
+													>
+														<input type="hidden" name="id" value={chat.id} />
+														<button type="submit" {...props}>
+															<ArchiveRestoreIcon />
+															<span>Restore</span>
+														</button>
+													</form>
+												{/snippet}
+											</DropdownMenu.Item>
+											<DropdownMenu.Separator />
+											<DropdownMenu.Item variant="destructive" closeOnSelect={false}>
+												{#snippet child({ props })}
+													<form
+														method="POST"
+														action="/?/deleteChat"
+														use:enhance={() =>
+															async ({ result, update }) => {
+																await update();
+																if (
+																	result.type === 'success' &&
+																	chatStore.currentChatId === chat.id
+																)
+																	goto(resolve('/'));
+															}}
+													>
+														<input type="hidden" name="id" value={chat.id} />
+														<button type="submit" {...props}>
+															<TrashIcon />
+															<span>Delete</span>
+														</button>
+													</form>
+												{/snippet}
+											</DropdownMenu.Item>
+										</DropdownMenu.Content>
+									</DropdownMenu.Root>
+								</Sidebar.MenuItem>
+							{/each}
+						</Sidebar.Menu>
+					</Sidebar.GroupContent>
+				{/if}
+			</Sidebar.Group>
+		{/if}
 	</Sidebar.Content>
 
 	<Sidebar.Footer>
@@ -103,3 +301,34 @@
 		</div>
 	</Sidebar.Footer>
 </Sidebar.Root>
+
+<Dialog.Root bind:open={renameOpen}>
+	<Dialog.Content>
+		<Dialog.Header>
+			<Dialog.Title>Rename chat</Dialog.Title>
+			<Dialog.Description>Give this chat a new title.</Dialog.Description>
+		</Dialog.Header>
+		<form
+			method="POST"
+			action="/?/renameChat"
+			use:enhance={() => {
+				const id = renameTarget?.id;
+				const title = renameValue.trim();
+				return async ({ result, update }) => {
+					await update();
+					if (result.type === 'success' && id) {
+						chatStore.updateChatTitle(id, title);
+						renameOpen = false;
+					}
+				};
+			}}
+		>
+			<input type="hidden" name="id" value={renameTarget?.id ?? ''} />
+			<Input name="title" bind:value={renameValue} placeholder="Chat title" autocomplete="off" />
+			<Dialog.Footer class="mt-4">
+				<Button type="button" variant="outline" onclick={() => (renameOpen = false)}>Cancel</Button>
+				<Button type="submit" disabled={!renameValue.trim()}>Save</Button>
+			</Dialog.Footer>
+		</form>
+	</Dialog.Content>
+</Dialog.Root>

--- a/src/lib/server/chat.service.ts
+++ b/src/lib/server/chat.service.ts
@@ -17,6 +17,19 @@ export async function getUserChats(userId: string) {
 		.orderBy(desc(chat.updatedAt));
 }
 
+export async function getArchivedChats(userId: string) {
+	return db
+		.select({
+			id: chat.id,
+			title: chat.title,
+			updatedAt: chat.updatedAt,
+			targetLanguage: chat.targetLanguage
+		})
+		.from(chat)
+		.where(and(eq(chat.userId, userId), eq(chat.archived, true)))
+		.orderBy(desc(chat.updatedAt));
+}
+
 export async function getChatById(chatId: string, userId: string) {
 	const [result] = await db
 		.select()
@@ -68,6 +81,13 @@ export async function updateChatTitle(chatId: string, userId: string, title: str
 	await db
 		.update(chat)
 		.set({ title })
+		.where(and(eq(chat.id, chatId), eq(chat.userId, userId)));
+}
+
+export async function setChatArchived(chatId: string, userId: string, archived: boolean) {
+	await db
+		.update(chat)
+		.set({ archived })
 		.where(and(eq(chat.id, chatId), eq(chat.userId, userId)));
 }
 

--- a/src/lib/stores/chat-store.svelte.ts
+++ b/src/lib/stores/chat-store.svelte.ts
@@ -2,6 +2,7 @@ import type { ChatSummary } from '$lib/types';
 
 class ChatStore {
 	chats = $state<ChatSummary[]>([]);
+	archivedChats = $state<ChatSummary[]>([]);
 	currentChatId = $state<string | null>(null);
 
 	get currentChat(): ChatSummary | null {
@@ -10,6 +11,10 @@ class ChatStore {
 
 	setChats(chats: ChatSummary[]) {
 		this.chats = chats;
+	}
+
+	setArchivedChats(chats: ChatSummary[]) {
+		this.archivedChats = chats;
 	}
 
 	addChat(chat: ChatSummary) {
@@ -22,6 +27,7 @@ class ChatStore {
 
 	updateChatTitle(id: string, title: string) {
 		this.chats = this.chats.map((c) => (c.id === id ? { ...c, title } : c));
+		this.archivedChats = this.archivedChats.map((c) => (c.id === id ? { ...c, title } : c));
 	}
 
 	setCurrentChatId(id: string | null) {

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,16 +1,19 @@
 import { redirect } from '@sveltejs/kit';
-import { getUserChats } from '$lib/server/chat.service';
+import { getArchivedChats, getUserChats } from '$lib/server/chat.service';
 
 const PUBLIC_ROUTES = ['/login', '/signup'];
 
 export const load = async ({ locals, url }) => {
 	if (PUBLIC_ROUTES.includes(url.pathname)) {
-		return { chats: [] };
+		return { chats: [], archivedChats: [] };
 	}
 
 	if (!locals.user) throw redirect(302, '/login');
 
-	const chats = await getUserChats(locals.user.id);
+	const [chats, archivedChats] = await Promise.all([
+		getUserChats(locals.user.id),
+		getArchivedChats(locals.user.id)
+	]);
 
-	return { chats };
+	return { chats, archivedChats };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -28,6 +28,7 @@
 
 	$effect(() => {
 		chatStore.setChats(data.chats);
+		chatStore.setArchivedChats(data.archivedChats);
 	});
 
 	$effect(() => {

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -1,5 +1,5 @@
 import { requireAuth } from '$lib/auth-validation';
-import { createChat, deleteChat } from '$lib/server/chat.service';
+import { createChat, deleteChat, setChatArchived, updateChatTitle } from '$lib/server/chat.service';
 import { fail, redirect } from '@sveltejs/kit';
 
 export const actions = {
@@ -25,6 +25,47 @@ export const actions = {
 		if (!id) return fail(400, { error: 'id required' });
 
 		await deleteChat(id, user.id);
+
+		return { success: true };
+	},
+
+	renameChat: async ({ request }) => {
+		const user = await requireAuth();
+
+		const data = await request.formData();
+		const id = data.get('id') as string;
+		const title = (data.get('title') as string)?.trim();
+
+		if (!id) return fail(400, { error: 'id required' });
+		if (!title) return fail(400, { error: 'title required' });
+
+		await updateChatTitle(id, user.id, title);
+
+		return { success: true };
+	},
+
+	archiveChat: async ({ request }) => {
+		const user = await requireAuth();
+
+		const data = await request.formData();
+		const id = data.get('id') as string;
+
+		if (!id) return fail(400, { error: 'id required' });
+
+		await setChatArchived(id, user.id, true);
+
+		return { success: true };
+	},
+
+	unarchiveChat: async ({ request }) => {
+		const user = await requireAuth();
+
+		const data = await request.formData();
+		const id = data.get('id') as string;
+
+		if (!id) return fail(400, { error: 'id required' });
+
+		await setChatArchived(id, user.id, false);
 
 		return { success: true };
 	}


### PR DESCRIPTION
## Summary

Improves the sidebar chat list per #20: groups chats by target language, adds search, rename, and wires up the previously unused `archived` flag.

- **Group by language** — active chats are grouped by `targetLanguage` with flag + label headers (`Sidebar.GroupLabel`).
- **Search** — a client-side input filters chats by title (applies to both active and archived lists).
- **Rename** — per-chat dropdown action opens a dialog that calls a new `renameChat` server action (reuses `updateChatTitle`).
- **Archive / Restore** — `archiveChat` / `unarchiveChat` server actions toggle the `archived` flag; archived chats appear in a collapsible **Archived** group with Restore / Delete. `getUserChats` already filters `archived = false`; added `getArchivedChats`.

Mutations use the existing `use:enhance` + `update()` invalidation pattern, so both lists refresh from the server after each action.

## Files
- `chat.service.ts` — `getArchivedChats`, `setChatArchived`
- `+page.server.ts` — `renameChat`, `archiveChat`, `unarchiveChat` actions
- `+layout.server.ts` / `+layout.svelte` — load + wire archived chats
- `chat-store.svelte.ts` — `archivedChats` state + setter
- `app-sidebar.svelte` — grouping, search, dropdown actions, rename dialog, archived group

## Validation
- Svelte MCP autofixer: no issues
- `bun run check`: 0 errors
- Prettier + ESLint: pass

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)