### PR TITLE
feat: streaming/typing indicator & disabled input during response

### DIFF
--- a/src/lib/components/chat-typing-indicator.svelte
+++ b/src/lib/components/chat-typing-indicator.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+
+	interface Props {
+		class?: string;
+	}
+
+	let { class: className }: Props = $props();
+</script>
+
+<div
+	class={cn('flex items-center gap-1 py-2', className)}
+	role="status"
+	aria-label="Tutor is typing"
+>
+	<span class="size-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.3s]"
+	></span>
+	<span class="size-2 animate-bounce rounded-full bg-muted-foreground/60 [animation-delay:-0.15s]"
+	></span>
+	<span class="size-2 animate-bounce rounded-full bg-muted-foreground/60"></span>
+	<span class="sr-only">Tutor is typing…</span>
+</div>

--- a/src/routes/chat/[id]/+page.svelte
+++ b/src/routes/chat/[id]/+page.svelte
@@ -9,6 +9,7 @@
 	import VocabularyDrawer from '$lib/components/vocabulary-drawer.svelte';
 	import VocabularyPanel from '$lib/components/vocabulary-panel.svelte';
 	import ChatWelcome from '$lib/components/chat-welcome.svelte';
+	import ChatTypingIndicator from '$lib/components/chat-typing-indicator.svelte';
 	import { chatStore } from '$lib/stores/chat-store.svelte.js';
 	import type { VocabEntry } from '$lib/types';
 	import { Chat } from '@ai-sdk/svelte';
@@ -79,11 +80,23 @@
 		}
 	});
 
+	let isResponding = $derived(chat.status === 'submitted' || chat.status === 'streaming');
+
+	// Show the typing indicator after sending and until the first assistant token arrives.
+	let showTypingIndicator = $derived.by(() => {
+		if (!isResponding) return false;
+		const last = chat.messages[chat.messages.length - 1];
+		if (last?.role !== 'assistant') return true;
+		return !(last.parts ?? []).some((part) => part.type === 'text' && part.text.trim().length > 0);
+	});
+
 	function handleSubmit(message: PromptMessage) {
+		if (isResponding) return;
 		chat.sendMessage({ text: message.text });
 	}
 
 	function handleWelcomeSend(text: string) {
+		if (isResponding) return;
 		chat.sendMessage({ text });
 	}
 </script>
@@ -113,6 +126,13 @@
 							</MessageContent>
 						</Message>
 					{/each}
+					{#if showTypingIndicator}
+						<Message from="assistant">
+							<MessageContent>
+								<ChatTypingIndicator />
+							</MessageContent>
+						</Message>
+					{/if}
 				</ChatContainerContent>
 			</ChatContainerRoot>
 
@@ -122,7 +142,7 @@
 						<PromptInput.Textarea placeholder="Type your message..." />
 					</PromptInput.Body>
 					<PromptInput.Toolbar class="justify-end">
-						<PromptInput.Submit />
+						<PromptInput.Submit status={chat.status} onStop={() => chat.stop()} />
 					</PromptInput.Toolbar>
 				</PromptInput.Root>
 			</div>


### PR DESCRIPTION
Closes #17

## What

Adds visible feedback while the tutor responds and prevents duplicate sends mid-stream.

- **Typing indicator** — new `chat-typing-indicator.svelte` (animated dots, `role="status"` + `sr-only` label). Shown after a message is sent and until the first assistant text token streams in (covers the `submitted`→`streaming` gap and tool-call latency).
- **Submit/stop control** — `PromptInput.Submit` wired to `chat.status` and `chat.stop()`, so it switches to a stop button while a response is in flight.
- **Block duplicate sends** — `handleSubmit`/`handleWelcomeSend` early-return while responding, covering the Enter-key path too.
- **Error/abort** — input and submit re-enable automatically since `isResponding` is false on `error`/`ready`; no extra handling needed.

## Validation

`bun run check` exits 0. The only remaining `svelte-check` output is a pre-existing `state_referenced_locally` warning on line 21 (`vocabulary = $state(data.chat.vocabulary)`), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)