### PR TITLE
feat: structured correction cards via addCorrection tool call

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ Use `SvelteMap` and `SvelteSet` over vanilla JS `Map` and `Set`.
 - Use stores over prop drilling when props pass through more than one intermediate component
 - Local `$state` when state is used only within one component
 
+### Types & Schemas
+
+App-wide types and Zod schemas live in `src/lib/types.ts`. Define schemas with Zod and derive TypeScript types from them with `z.infer`. Keep type definitions out of feature files — if a type is used in more than one place, or could be, it belongs in `types.ts`.
+
 ### UI Components
 
 - shadcn-svelte components live in `src/lib/components/ui/`

--- a/src/lib/components/chat/chat-message-list.svelte
+++ b/src/lib/components/chat/chat-message-list.svelte
@@ -6,7 +6,9 @@
 	} from '$lib/components/prompt-kit/chat-container';
 	import ChatWelcome from './chat-welcome.svelte';
 	import ChatTypingIndicator from './chat-typing-indicator.svelte';
+	import CorrectionCard from './correction-card.svelte';
 	import type { Chat } from '@ai-sdk/svelte';
+	import type { Correction } from '$lib/types';
 
 	interface Props {
 		messages: Chat['messages'];
@@ -32,6 +34,16 @@
 								content={msgPart.text}
 								class="**:my-3 {message.role === 'user' ? '**:text-white' : ''}"
 							/>
+						{:else if msgPart.type === 'tool-addCorrection'}
+							{@const toolPart = msgPart as { state: string; input?: Correction }}
+							{#if (toolPart.state === 'input-available' || toolPart.state === 'output-available') && toolPart.input}
+								<CorrectionCard
+									original={toolPart.input.original}
+									corrected={toolPart.input.corrected}
+									explanation={toolPart.input.explanation}
+									severity={toolPart.input.severity}
+								/>
+							{/if}
 						{/if}
 					{/each}
 				</MessageContent>

--- a/src/lib/components/chat/correction-card.svelte
+++ b/src/lib/components/chat/correction-card.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import { cn } from '$lib/utils';
+	import type { Correction } from '$lib/types';
+
+	type Props = Correction;
+
+	const { original, corrected, explanation, severity }: Props = $props();
+</script>
+
+<div
+	class={cn(
+		'my-1 rounded-r-md border-l-4 bg-white px-3 py-2 text-sm dark:bg-zinc-900',
+		severity === 'minor' && 'border-amber-400',
+		severity === 'major' && 'border-rose-500',
+		!severity && 'border-zinc-300 dark:border-zinc-600'
+	)}
+>
+	<div class="mb-1 flex items-center gap-2">
+		<span
+			class={cn(
+				'rounded px-1.5 py-0.5 text-xs font-semibold tracking-wide uppercase',
+				severity === 'minor' &&
+					'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
+				severity === 'major' && 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-400',
+				!severity && 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+			)}
+		>
+			Correction
+		</span>
+	</div>
+
+	<div class="flex flex-wrap items-baseline gap-1.5">
+		<span class="text-zinc-400 line-through dark:text-zinc-500">{original}</span>
+		<span class="text-zinc-400 dark:text-zinc-500">→</span>
+		<span
+			class={cn(
+				'font-semibold',
+				severity === 'minor' && 'text-amber-700 dark:text-amber-400',
+				severity === 'major' && 'text-rose-700 dark:text-rose-400',
+				!severity && 'text-zinc-800 dark:text-zinc-100'
+			)}
+		>
+			{corrected}
+		</span>
+	</div>
+
+	<p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">{explanation}</p>
+</div>

--- a/src/lib/components/chat/correction-card.svelte
+++ b/src/lib/components/chat/correction-card.svelte
@@ -9,20 +9,19 @@
 
 <div
 	class={cn(
-		'my-1 rounded-r-md border-l-4 bg-white px-3 py-2 text-sm dark:bg-zinc-900',
+		'my-1 rounded-r-md border-l-4 bg-white px-3 pb-1 text-sm dark:bg-zinc-900',
 		severity === 'minor' && 'border-amber-400',
 		severity === 'major' && 'border-rose-500',
 		!severity && 'border-zinc-300 dark:border-zinc-600'
 	)}
 >
-	<div class="mb-1 flex items-center gap-2">
+	<div class="mb-1">
 		<span
 			class={cn(
-				'rounded px-1.5 py-0.5 text-xs font-semibold tracking-wide uppercase',
-				severity === 'minor' &&
-					'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-400',
-				severity === 'major' && 'bg-rose-100 text-rose-700 dark:bg-rose-900/40 dark:text-rose-400',
-				!severity && 'bg-zinc-100 text-zinc-500 dark:bg-zinc-800 dark:text-zinc-400'
+				'text-[8px] font-medium tracking-widest uppercase',
+				severity === 'minor' && 'text-amber-500 dark:text-amber-400',
+				severity === 'major' && 'text-rose-500 dark:text-rose-400',
+				!severity && 'text-zinc-400 dark:text-zinc-600'
 			)}
 		>
 			Correction

--- a/src/lib/languages.ts
+++ b/src/lib/languages.ts
@@ -1,8 +1,4 @@
-export interface Language {
-	value: string;
-	label: string;
-	flag: string;
-}
+import type { Language } from '$lib/types';
 
 export const LANGUAGES: Language[] = [
 	{ value: 'Spanish', label: 'Spanish', flag: '🇪🇸' },

--- a/src/lib/server/ai-tools.ts
+++ b/src/lib/server/ai-tools.ts
@@ -1,5 +1,5 @@
 import { getChatVocabulary, updateChatTitle, updateChatVocabulary } from '$lib/server/chat.service';
-import { VocabEntrySchema, type VocabEntry } from '$lib/types';
+import { CorrectionSchema, VocabEntrySchema, type VocabEntry } from '$lib/types';
 import { tool } from 'ai';
 import { z } from 'zod';
 
@@ -44,5 +44,12 @@ export function createChatTools(chatId: string, userId: string) {
 		}
 	});
 
-	return { addVocabulary, updateChatTitle: updateTitle };
+	const addCorrection = tool({
+		description:
+			'Report a grammar or vocabulary mistake the user made. Call this once per distinct mistake, inline with your response, at the point where you address the correction.',
+		inputSchema: CorrectionSchema,
+		execute: async (input) => input
+	});
+
+	return { addVocabulary, updateChatTitle: updateTitle, addCorrection };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,14 @@
 import type { Chat } from './chat-schema';
 import { z } from 'zod';
 
+export const LanguageSchema = z.object({
+	value: z.string(),
+	label: z.string(),
+	flag: z.string()
+});
+
+export type Language = z.infer<typeof LanguageSchema>;
+
 export type ChatSummary = Pick<Chat, 'id' | 'title' | 'updatedAt' | 'targetLanguage'>;
 
 export const VocabEntrySchema = z.object({

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,3 +11,15 @@ export const VocabEntrySchema = z.object({
 });
 
 export type VocabEntry = z.infer<typeof VocabEntrySchema>;
+
+export const CorrectionSchema = z.object({
+	original: z.string().describe("The user's original, incorrect phrase or word"),
+	corrected: z.string().describe('The corrected phrase or word in the target language'),
+	explanation: z.string().describe('A brief explanation of why the correction was needed'),
+	severity: z
+		.enum(['minor', 'major'])
+		.optional()
+		.describe('How significant the mistake is — minor for small slips, major for key errors')
+});
+
+export type Correction = z.infer<typeof CorrectionSchema>;

--- a/src/routes/api/chat/system-prompt.ts
+++ b/src/routes/api/chat/system-prompt.ts
@@ -16,6 +16,7 @@ export function buildSystemPrompt({ targetLanguage }: { targetLanguage: string }
 - Avoid engaging with harmful, offensive, or inappropriate content. Redirect such topics back to language practice.
 
 ## Tool usage
+- Whenever you correct a grammar or vocabulary mistake in the user's message, call the addCorrection tool once per distinct mistake. Call it inline, at the point in your response where you address the correction, so corrections appear in context. Provide the user's original phrasing, the corrected form, and a short explanation. Mark severity as "minor" for small slips (accent, article) and "major" for errors that significantly affect meaning.
 - At the end of every response, call the addVocabulary tool with any new vocabulary words you introduced in this response. Include the target-language word, its English translation, its grammatical part of speech, and a usage example sentence in the target language. If you did not introduce any new words, call addVocabulary with an empty array.
 - Early in the conversation, once the topic or purpose of the session becomes clear (typically after the user's first two or three messages), call the updateChatTitle tool once with a short, descriptive title summarizing the conversation. Keep it concise (around five words or fewer) and write it in ${targetLanguage}. Do not call this tool again afterwards unless the conversation clearly shifts to an entirely different topic.`;
 }


### PR DESCRIPTION
Closes #18

## Summary
- Adds `addCorrection` tool (server) that the AI tutor calls inline whenever it corrects a user mistake — input schema is display-only (echoes input, no DB write)
- `CorrectionSchema` and `Correction` type extracted to `src/lib/types.ts` so both server tools and client components share the same definition
- New `CorrectionCard` component renders each correction as a scannable card: strikethrough original → bold corrected, explanation below, severity-coloured left border (amber = minor, rose = major)
- `ChatMessageList` renders `CorrectionCard` inline within the message parts loop for `tool-addCorrection` parts once `input-available`
- System prompt updated to instruct the model to call `addCorrection` inline per distinct mistake

## Test plan
- [ ] Send a message with a grammar mistake in the target language and confirm a correction card appears inline in the assistant reply
- [ ] Verify minor vs major severity produces the correct border/badge colour (amber vs rose)
- [ ] Verify messages without mistakes render normally with no correction cards
- [ ] Confirm correction cards persist after page reload (parts are stored in message history)
- [ ] Check dark mode rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)